### PR TITLE
Securing remember me cookie token

### DIFF
--- a/index.php
+++ b/index.php
@@ -22,6 +22,14 @@ echo new Init(new class
         'perp'  => 25,
         'self'  => '',
     ],
+    $sess_cookie = [
+        'name' => 'HCPSESS',
+        'lifetime' => 0,
+        'path' => '',
+        'domain' => '',
+        'secure' => false,
+        'httponly' => true
+    ],
     $in = [
         'd'     => '',          // Domain (current)
         'g'     => null,        // Group/Category

--- a/lib/php/init.php
+++ b/lib/php/init.php
@@ -14,7 +14,7 @@ error_log(__METHOD__);
             ? $g->cfg['host']
             : getenv('HOSTNAME');
 
-        session_start();
+        Util::session_start($g->sess_cookie);
         //$_SESSION = []; // to reset session for testing
 error_log('GET=' . var_export($_GET, true));
 

--- a/lib/php/plugins/accounts.php
+++ b/lib/php/plugins/accounts.php
@@ -32,20 +32,20 @@ error_log(__METHOD__);
             $wval = $_SESSION['usr']['id'];
          }
 
-//        return $this->t->list(db::read('*')),
-        return $this->t->list(db::read('*', '', '', 'ORDER BY `updated` DESC'));
-/*
-        $pager = util::pager(
-            (int) util::ses('p'),
-            (int) $this->g->cfg['perp'],
-            (int) db::read('count(id)', $where, $wval, '', 'col')
-        );
+        //return $this->t->list(db::read('*')),
+        return $this->t->list(db::read('*', $where, $wval, 'ORDER BY `updated` DESC'));
 
-        return $this->t->list(array_merge(
-            db::read('*', $where, $wval, 'ORDER BY `updated` DESC LIMIT ' . $pager['start'] . ',' . $pager['perp']),
-            ['pager' => $pager]
-        ));
-*/
+        // $pager = util::pager(
+        //     (int) util::ses('p'),
+        //     (int) $this->g->cfg['perp'],
+        //     (int) db::read('count(id)', $where, $wval, '', 'col')
+        // );
+
+        // return $this->t->list(array_merge(
+        //     db::read('*', $where, $wval, 'ORDER BY `updated` DESC LIMIT ' . $pager['start'] . ',' . $pager['perp']),
+        //     ['pager' => $pager]
+        // ));
+
     }
 
     protected function switch_user()

--- a/lib/php/plugins/auth.php
+++ b/lib/php/plugins/auth.php
@@ -62,7 +62,6 @@ error_log(__METHOD__);
                         $uniq = Util::random_token(32);
                         if ($this->in['remember']) {
                             db::update(['cookie' => $uniq], [['id', '=', $id]]);
-                            util::put_cookie('remember', $uniq, strtotime('7 days', 0), $this->g->cfg['host'], $this->g->cfg['self'], true, true);
                             self::setcookie('remember', $uniq, self::REMEMBER_ME_EXP);
                         }
                         $_SESSION['usr'] = $usr;
@@ -126,10 +125,14 @@ error_log(__METHOD__);
 
         if(Util::is_usr()){
             $u = $_SESSION['usr']['login'];
+            $id = $_SESSION['usr']['id'];
             if (isset($_SESSION['adm']) and $_SESSION['usr']['id'] === $_SESSION['adm'])
                 unset($_SESSION['adm']);
             unset($_SESSION['usr']);
-            self::setcookie('remember', '', strtotime('-1 hour', 0));
+            if(isset($_COOKIE['remember'])){
+                db::update(['cookie' => ''], [['id', '=', $id]]);
+                self::setcookie('remember', '', strtotime('-1 hour', 0));
+             }
             util::log($u . ' is now logged out', 'success');
         }
         header('Location: ' . $this->g->cfg['self']);

--- a/lib/php/plugins/auth.php
+++ b/lib/php/plugins/auth.php
@@ -30,7 +30,7 @@ error_log(__METHOD__);
             if (filter_var($u, FILTER_VALIDATE_EMAIL)) {
                 if ($usr = db::read('id,acl', 'login', $u, '', 'one')) {
                     if ($usr['acl'] != 9) {
-                        $newpass = util::genpw(slef::OTP_LENGTH);
+                        $newpass = util::genpw(self::OTP_LENGTH);
                         if ($this->mail_forgotpw($u, $newpass, 'From: ' . $this->g->cfg['email'])) {
                             db::update([
                                 'otp' => $newpass,

--- a/lib/php/plugins/auth.php
+++ b/lib/php/plugins/auth.php
@@ -62,7 +62,7 @@ error_log(__METHOD__);
                         $uniq = Util::random_token(32);
                         if ($this->in['remember']) {
                             db::update(['cookie' => $uniq], [['id', '=', $id]]);
-                            self::setcookie('remember', $uniq, self::REMEMBER_ME_EXP);
+                            $this->setcookie('remember', $uniq, self::REMEMBER_ME_EXP);
                         }
                         $_SESSION['usr'] = $usr;
                         util::log($login.' is now logged in', 'success');
@@ -131,7 +131,7 @@ error_log(__METHOD__);
             unset($_SESSION['usr']);
             if(isset($_COOKIE['remember'])){
                 db::update(['cookie' => ''], [['id', '=', $id]]);
-                self::setcookie('remember', '', strtotime('-1 hour', 0));
+                $this->setcookie('remember', '', strtotime('-1 hour', 0));
              }
             util::log($u . ' is now logged out', 'success');
         }

--- a/lib/php/plugins/auth.php
+++ b/lib/php/plugins/auth.php
@@ -189,7 +189,8 @@ error_log(__METHOD__);
          * secure HTTPS connection from the client, and
          * must be accessible only through the HTTP protocol.
          */
-        return setcookie($name, $value, time() + $expire, $this->g->cfg['self'], '', true, true);
+        $expire = $expire ? time() + $expire : 0;
+        return setcookie($name, $value, $expire, $this->g->cfg['self'], '', true, true);
     }
 }
 

--- a/lib/php/util.php
+++ b/lib/php/util.php
@@ -326,6 +326,28 @@ error_log(__METHOD__);
 
         return substr($random_base64, 0, $length);
     }
+
+    public static function session_start(array $cfg) : bool
+    {
+error_log(__METHOD__);
+
+        /**
+         * Default session cookie paramters
+         * http://php.net/manual/en/session.configuration.php
+         */
+        $_sess_cookie_params = session_get_cookie_params();
+
+        $name     = $cfg['name'] ?? session_name();
+        $lifetime = $cfg['lifetime'] ?? $_sess_cookie_params['lifetime'];
+        $path     = $cfg['path'] ?? $_sess_cookie_params['path'];
+        $domain   = $cfg['domain'] ?? $_sess_cookie_params['domain'];
+        $secure   = $cfg['secure'] ?? $_sess_cookie_params['secure'];
+        $httponly = $cfg['httponly'] ?? $_sess_cookie_params['httponly'];
+
+        session_name($name);
+        session_set_cookie_params($lifetime, $path, $domain, $secure, $httponly);
+        return session_start();
+    }
 }
 
 ?>

--- a/lib/php/util.php
+++ b/lib/php/util.php
@@ -176,11 +176,11 @@ error_log(__METHOD__);
         return $_COOKIE[$name] ?? $default;
     }
 
-    public static function put_cookie(string $name, string $value, int $expiry=604800, $path = '/', string $domain = '', bool $secure=false, bool $httponly=false) : string
+    public static function put_cookie(string $name, string $value, int $expiry=604800) : string
     {
 error_log(__METHOD__);
 
-        return setcookie($name, $value, time() + $expiry, $path, $domain, $secure, $httponly) ? $value : '';
+        return setcookie($name, $value, time() + $expiry) ? $value : '';
     }
 
     public static function del_cookie(string $name) : string


### PR DESCRIPTION
I have added a new method to the `Auth` class, called `setcookie()` which sets the cookies related to the authentication like remember me cookie token. The difference between `Util::put_cookie` and `Auth::setcookie`, is that the last once creates a secure cookie, which must not be accessible through any scripting language on user's browser, also must be transmetted only over HTTPs requests.