### PR TITLE
Remove accounts::__construct()

### DIFF
--- a/lib/php/plugins/accounts.php
+++ b/lib/php/plugins/accounts.php
@@ -17,15 +17,6 @@ class Plugins_Accounts extends Plugin
         //'webpw'     => '',
     ];
 
-    public function __construct(Theme $t)
-    {
-        if (!util::is_usr()) {
-            $_SESSION['redirect_to'] = $_SERVER[''];
-            util::redirect($this->g->cfg['self'] . '?o=auth', 0, '');
-        }
-        parent::__construct($t);
-    }
-
     protected function create() : string
     {
         if (util::is_adm()) return parent::create();


### PR DESCRIPTION
There's no need to check if the user is logged-in, as this is already done under Plugin::__contruct().